### PR TITLE
TRUS-4487 [CS] add two thirds width class to CYA key

### DIFF
--- a/app/views/components/CheckDetailsRow.scala.html
+++ b/app/views/components/CheckDetailsRow.scala.html
@@ -21,7 +21,7 @@
 @(row: AnswerRow)(implicit messages: Messages)
 
 <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
+    <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
         @row.label
     </dt>
     <dd class="govuk-summary-list__value">


### PR DESCRIPTION
Before:
<img width="1187" alt="check trust details before 2021-08-23 at 11 00 11" src="https://user-images.githubusercontent.com/62263396/130435774-94396b20-589b-44fc-9892-10765a03d566.png">

After two thirds class added:
<img width="1179" alt="two-thirds class added 2021-08-23 at 11 11 33" src="https://user-images.githubusercontent.com/62263396/130435860-7098f3ed-ee40-43bb-9ab1-29fab5e65868.png">

